### PR TITLE
Remove JAIS info option from LLM chat, go straight to complaint flow

### DIFF
--- a/api/config/llm.php
+++ b/api/config/llm.php
@@ -22,30 +22,8 @@ PERATURAN UMUM:
 PERMULAAN PERBUALAN:
 Pada permulaan perbualan, balas dengan mesej ini SAHAJA (tepat seperti di bawah):
 
-Salam sejahtera, Saya pembantu maya (AI) rasmi Jabatan Agama Islam Selangor (JAIS). Saya sedia membantu anda dengan perkhidmatan berikut;
+Salam sejahtera, Saya pembantu maya (AI) rasmi Jabatan Agama Islam Selangor (JAIS). Saya sedia membantu anda untuk membuat aduan.
 
-1. Maklumat mengenai JAIS
-2. Membuat aduan
-
-Sila nyatakan pilihan anda (1 atau 2)
-
-JIKA PENGGUNA MEMILIH 1:
-Balas dengan maklumat berikut sahaja:
-
-JAIS ialah institusi yang menguruskan hal ehwal Islam di Negeri Selangor.
-
-Alamat:
-Jabatan Agama Islam Selangor (JAIS)
-Bangunan Sultan Idris Shah
-No. 2 Persiaran Masjid
-40676 Shah Alam, Selangor
-
-Telefon: 03-5514 3600 / 3400
-Faks: 03-5510 3368
-Emel: info@jais.gov.my
-Laman web : https://www.jais.gov.my
-
-JIKA PENGGUNA MEMILIH 2 (MEMBUAT ADUAN):
 Maklumkan bahawa beberapa maklumat diperlukan untuk membuat aduan.
 Tanya soalan SATU PERSATU mengikut urutan berikut:
 1. Nama penuh


### PR DESCRIPTION
Removes option 1 ("Maklumat mengenai JAIS") from the LLM complaint bot's system prompt so the only path is making a complaint.

## Changes
- `api/config/llm.php` — the bot now greets the user and goes straight into the complaint intake flow, instead of presenting a 1/2 menu. Removed the option menu, the "Sila nyatakan pilihan" prompt, and the entire "JIKA PENGGUNA MEMILIH 1" branch (JAIS address/contact block).
- Complaint questions, confirmation summary, and `/store_complaint` logic are unchanged.

Note: as this is a config file, run `php artisan config:clear` (or re-cache) on the server for the new prompt to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011av6XmngWp3biDjRTNK4ng

---
_Generated by [Claude Code](https://claude.ai/code/session_011av6XmngWp3biDjRTNK4ng)_