### PR TITLE
Make LLM complaint location a picker of active districts

### DIFF
--- a/api/app/Services/LlmComplaintService.php
+++ b/api/app/Services/LlmComplaintService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\ChatMessage;
 use App\Models\Complaint;
+use App\Models\District;
 use App\Services\ComplaintReferenceService;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -81,6 +82,23 @@ class LlmComplaintService
             ->toArray();
 
         $systemMessages = [['role' => 'system', 'content' => config('llm.complaint_system_prompt')]];
+
+        $activeDistricts = District::where('is_active', true)
+            ->orderBy('id')
+            ->pluck('name')
+            ->all();
+        if ($activeDistricts) {
+            $lines = [];
+            foreach ($activeDistricts as $index => $name) {
+                $lines[] = ($index + 1) . '. ' . $name;
+            }
+            $systemMessages[] = [
+                'role'    => 'system',
+                'content' => "SENARAI DAERAH AKTIF (untuk soalan 'Daerah kejadian'):\n" . implode("\n", $lines) .
+                    "\n\nARAHAN: Paparkan senarai ini apabila bertanya soalan daerah. Terima hanya daerah yang ada dalam senarai. Simpan nama daerah yang dipilih (bukan nombor) sebagai 'district'.",
+            ];
+        }
+
         if ($hints) {
             $lines = [];
             if (!empty($hints['name'])) {
@@ -175,7 +193,7 @@ class LlmComplaintService
             'complainant_name'     => $complainantName,
             'identification_number' => $data['identification_number'] ?? 'Tidak dinyatakan',
             'contact_number'       => $contactNumber,
-            'address'              => $data['location'] ?? 'Tidak dinyatakan',
+            'address'              => $data['location'] ?? $data['district'] ?? 'Tidak dinyatakan',
             'district_name'        => $data['district'] ?? null,
             'summary'              => (Str::startsWith($channel, 'whatsapp') ? '[TEST] ' : '') . ($data['contents'] ?? 'Tidak dinyatakan'),
             'channel'              => $channel,

--- a/api/config/llm.php
+++ b/api/config/llm.php
@@ -29,7 +29,7 @@ Tanya soalan SATU PERSATU mengikut urutan berikut:
 1. Nama penuh
 2. Nombor kad pengenalan
 3. Nombor telefon
-4. Lokasi kejadian
+4. Daerah kejadian
 5. Butiran aduan
 
 Peraturan aduan:
@@ -38,6 +38,7 @@ Peraturan aduan:
 - Jangan menambah soalan lain.
 - Jangan memberi komen atau penilaian.
 - Simpan semua maklumat yang diterima sehingga aduan lengkap.
+- Untuk soalan 'Daerah kejadian', paparkan SENARAI DAERAH AKTIF yang diberikan kepada anda dan minta pengguna memilih satu. Terima hanya daerah yang ada dalam senarai tersebut. Jika pengguna memberi jawapan di luar senarai, paparkan semula senarai dan minta pengguna memilih semula.
 
 Apabila SEMUA maklumat telah lengkap:
 - paparkan ringkasan aduan kepada pengguna untuk pengesahan dalam format berikut (isi setiap medan dengan maklumat yang telah diterima daripada pengguna):
@@ -47,7 +48,7 @@ Terima kasih. Berikut ringkasan aduan anda;
 Nama penuh : <nama penuh>
 Nombor kad pengenalan : <nombor kad pengenalan>
 Nombor telefon : <nombor telefon>
-Lokasi kejadian : <lokasi kejadian>
+Daerah kejadian : <daerah>
 Butiran aduan : <butiran aduan>
 
 - minta pengesahan pengguna untuk menghantar aduan (ya/tidak).
@@ -55,7 +56,7 @@ Butiran aduan : <butiran aduan>
 - jika pengguna menjawab 'ya', bina arahan /store_complaint seperti di bawah
 - Balas dengan SATU baris arahan sahaja dalam format berikut:
 
-/store_complaint {"name":"<nama penuh>","identification_number":"<nombor kad pengenalan>","contact_number":"<nombor telefon>","location":"<lokasi kejadian>","contents":"<butiran aduan>"}
+/store_complaint {"name":"<nama penuh>","identification_number":"<nombor kad pengenalan>","contact_number":"<nombor telefon>","district":"<daerah>","contents":"<butiran aduan>"}
 
 Pastikan JSON adalah sah dan jangan sertakan sebarang ayat lain.
 


### PR DESCRIPTION
The complaint bot's location question now presents the active districts and requires the user to pick one, instead of accepting free text.

## Changes
- `api/config/llm.php` — question 4 changed from free-text "Lokasi kejadian" to "Daerah kejadian" with an instruction to show the active-districts list and accept only a value from it. Confirmation summary and the `/store_complaint` JSON now use `district` instead of `location`.
- `api/app/Services/LlmComplaintService.php` — `askOpenAi()` injects a numbered list of active districts (`District::where('is_active', true)`) into the prompt dynamically, so it stays in sync with the `is_active` flag. Added the `District` import; `storeComplaint()` address fallback now uses the chosen district when no free-text location is present.

Side effect: the picked daerah now flows into `district_name` and reference-number generation (previously defaulted to "Tidak Diketahui").

Note: run `php artisan config:clear` on the server for the prompt change to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011av6XmngWp3biDjRTNK4ng

---
_Generated by [Claude Code](https://claude.ai/code/session_011av6XmngWp3biDjRTNK4ng)_