### PR TITLE
Stop LLM asking for phone number; use WABA-supplied number

### DIFF
--- a/api/app/Services/LlmComplaintService.php
+++ b/api/app/Services/LlmComplaintService.php
@@ -104,20 +104,9 @@ class LlmComplaintService
             if (!empty($hints['name'])) {
                 $lines[] = "- Nama pengguna (dari profil WhatsApp): {$hints['name']}";
             }
-            if (!empty($hints['phone'])) {
-                $lines[] = "- Nombor telefon (dari WhatsApp): {$hints['phone']}";
-            }
             if ($lines) {
                 $content = "MAKLUMAT PENGGUNA YANG TELAH DIKENAL:\n" . implode("\n", $lines) .
                     "\n\nARAHAN: Gunakan maklumat ini sebagai nilai lalai. Jika pengguna membetulkan maklumat ini, gunakan versi yang dibetulkan.";
-
-                if (!empty($hints['phone'])) {
-                    $content .= "\n\nARAHAN KHUSUS NOMBOR TELEFON:" .
-                        "\n- Nombor telefon pengguna SUDAH DIKETAHUI daripada WhatsApp: {$hints['phone']}." .
-                        "\n- JANGAN tanya nombor telefon. LANGKAU soalan nombor telefon dalam urutan soalan." .
-                        "\n- Dalam ringkasan pengesahan, isi baris 'Nombor telefon' dengan {$hints['phone']}." .
-                        "\n- Dalam arahan /store_complaint, isi 'contact_number' dengan {$hints['phone']}.";
-                }
 
                 $systemMessages[] = [
                     'role'    => 'system',

--- a/api/config/llm.php
+++ b/api/config/llm.php
@@ -28,9 +28,10 @@ Maklumkan bahawa beberapa maklumat diperlukan untuk membuat aduan.
 Tanya soalan SATU PERSATU mengikut urutan berikut:
 1. Nama penuh
 2. Nombor kad pengenalan
-3. Nombor telefon
-4. Daerah kejadian
-5. Butiran aduan
+3. Daerah kejadian
+4. Butiran aduan
+
+JANGAN tanya nombor telefon. Nombor telefon pengguna diperoleh secara automatik daripada WhatsApp dan tidak perlu ditanya.
 
 Peraturan aduan:
 - Tanya satu soalan pada satu masa sahaja.
@@ -47,7 +48,6 @@ Terima kasih. Berikut ringkasan aduan anda;
 
 Nama penuh : <nama penuh>
 Nombor kad pengenalan : <nombor kad pengenalan>
-Nombor telefon : <nombor telefon>
 Daerah kejadian : <daerah>
 Butiran aduan : <butiran aduan>
 
@@ -56,7 +56,7 @@ Butiran aduan : <butiran aduan>
 - jika pengguna menjawab 'ya', bina arahan /store_complaint seperti di bawah
 - Balas dengan SATU baris arahan sahaja dalam format berikut:
 
-/store_complaint {"name":"<nama penuh>","identification_number":"<nombor kad pengenalan>","contact_number":"<nombor telefon>","district":"<daerah>","contents":"<butiran aduan>"}
+/store_complaint {"name":"<nama penuh>","identification_number":"<nombor kad pengenalan>","district":"<daerah>","contents":"<butiran aduan>"}
 
 Pastikan JSON adalah sah dan jangan sertakan sebarang ayat lain.
 


### PR DESCRIPTION
The complaint bot no longer asks for a phone number, since WhatsApp supplies the sender's number.

## Changes
- `api/config/llm.php` — removed the phone question (intake is now Nama penuh → Nombor kad pengenalan → Daerah kejadian → Butiran aduan), added an explicit "do not ask for phone" instruction, and dropped the phone line from the summary and `contact_number` from the `/store_complaint` JSON.
- `api/app/Services/LlmComplaintService.php` — removed the redundant phone hint instructions. The phone is still used server-side: `storeComplaint()` sets `contact_number` from `hints['phone']`, falling back to the chat id (which for WhatsApp is the sender's number).

Note: Telegram doesn't supply a phone, so Telegram complaints store the Telegram chat id as `contact_number` (same fallback as before, just no longer asked).

Run `php artisan config:clear` on the server for the prompt change to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011av6XmngWp3biDjRTNK4ng

---
_Generated by [Claude Code](https://claude.ai/code/session_011av6XmngWp3biDjRTNK4ng)_