### PR TITLE
Remove [TEST] prefix from WhatsApp complaint summaries

### DIFF
--- a/api/app/Services/LlmComplaintService.php
+++ b/api/app/Services/LlmComplaintService.php
@@ -184,7 +184,7 @@ class LlmComplaintService
             'contact_number'       => $contactNumber,
             'address'              => $data['location'] ?? $data['district'] ?? 'Tidak dinyatakan',
             'district_name'        => $data['district'] ?? null,
-            'summary'              => (Str::startsWith($channel, 'whatsapp') ? '[TEST] ' : '') . ($data['contents'] ?? 'Tidak dinyatakan'),
+            'summary'              => $data['contents'] ?? 'Tidak dinyatakan',
             'channel'              => $channel,
             'current_stage'        => 'baru',
             'submitted_at'         => $now,


### PR DESCRIPTION
WhatsApp complaints are going live, so stop tagging their summary with a `[TEST]` prefix.

## Changes
- `api/app/Services/LlmComplaintService.php` — `storeComplaint()` now stores `$data['contents']` directly as the summary, instead of prepending `[TEST] ` for `whatsapp*` channels.

Run `php artisan config:clear` on the server if config is cached (no prompt change here, but included for consistency with recent deploys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011av6XmngWp3biDjRTNK4ng

---
_Generated by [Claude Code](https://claude.ai/code/session_011av6XmngWp3biDjRTNK4ng)_